### PR TITLE
Add get_trimmed_path() in input.rs 

### DIFF
--- a/rapx/src/analysis/testgen/generator/ltgen/mono.rs
+++ b/rapx/src/analysis/testgen/generator/ltgen/mono.rs
@@ -208,8 +208,8 @@ fn get_mono_set<'tcx>(
                                 }
                             }
 
-                            reachable_set.add_from_iter(fresh_args.iter().map(|arg| {
-                                match arg.kind() {
+                            reachable_set.add_from_iter(fresh_args.iter().map(
+                                |arg| match arg.kind() {
                                     ty::GenericArgKind::Lifetime(region) => {
                                         infcx.resolve_vars_if_possible(region).into()
                                     }
@@ -219,8 +219,8 @@ fn get_mono_set<'tcx>(
                                     ty::GenericArgKind::Const(ct) => {
                                         infcx.resolve_vars_if_possible(ct).into()
                                     }
-                                }
-                            }));
+                                },
+                            ));
                         });
                         reachable_set
                     });

--- a/rapx/src/analysis/testgen/syn/impls.rs
+++ b/rapx/src/analysis/testgen/syn/impls.rs
@@ -27,15 +27,12 @@ impl<I: InputGen> FuzzDriverSynImpl<I> {
                 // let generics = cx.tcx().generics_of(call.fn_did());
                 let tcx = cx.tcx();
 
-                let args = call
-                    .generic_args()
-                    .into_iter()
-                    .map(|arg| match arg.kind() {
-                        ty::GenericArgKind::Lifetime(_) => {
-                            ty::GenericArg::from(tcx.lifetimes.re_erased)
-                        }
-                        _ => *arg,
-                    });
+                let args = call.generic_args().into_iter().map(|arg| match arg.kind() {
+                    ty::GenericArgKind::Lifetime(_) => {
+                        ty::GenericArg::from(tcx.lifetimes.re_erased)
+                    }
+                    _ => *arg,
+                });
 
                 format!(
                     "{}({})",

--- a/rapx/src/analysis/testgen/utils.rs
+++ b/rapx/src/analysis/testgen/utils.rs
@@ -21,7 +21,7 @@ use std::collections::VecDeque;
 /// return all DefId of all pub APIs
 pub fn get_all_pub_apis(tcx: TyCtxt<'_>) -> Vec<DefId> {
     let mut apis = Vec::new();
-    
+
     for local_def_id in tcx.hir_body_owners() {
         if matches!(tcx.hir_body_owner_kind(local_def_id), BodyOwnerKind::Fn)
             && is_api_public(local_def_id, tcx)


### PR DESCRIPTION
add get_trimmed_path() in input.rs , which can be modified by adding &'tcx [GenericArg<'tcx>] as a parameter for better usage, because now set args as &[ ] by default.